### PR TITLE
Allow the latest HTTParty version

### DIFF
--- a/kempelen.gemspec
+++ b/kempelen.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "ruby-hmac", "~> 0.4.0"
   spec.add_dependency "nori", "~> 2.6.0"
-  spec.add_dependency "httparty", "~> 0.13.6"
+  spec.add_dependency "httparty", ">= 0.13.0"
 
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 11.1"


### PR DESCRIPTION
HTTParty 0.14.0 has no breaking changes from 0.13.7, but the gemspec is too strict to allow it.